### PR TITLE
Convert BPManagedCommand to a non-UObject

### DIFF
--- a/Source/ButtplugUE/Private/BPDeviceSubsystem.cpp
+++ b/Source/ButtplugUE/Private/BPDeviceSubsystem.cpp
@@ -267,10 +267,10 @@ int32 UBPDeviceSubsystem::StopDevice(const FBPDeviceObject& Device, FBPInstanced
 		BPLog::Error(this, "Tried to send message while not connected!");
 		return -1;
 	}
+
 	if(bStopPatterns)
 	{
-		//for(const TPair<FGuid, UBPManagedCommand*> Command : ManagedCommands)
-		TArray<UBPManagedCommand*> Commands;
+		TArray<TSharedPtr<FBPManagedCommand>> Commands;
 		ManagedCommands.GenerateValueArray(Commands);
 		for(int i = 0; i < Commands.Num(); i++)
 		{
@@ -292,11 +292,10 @@ int32 UBPDeviceSubsystem::StopAllDevices(FBPInstancedResponseDelegate Response, 
 	}
 	if (bStopPatterns)
 	{
-		for (const TPair<FGuid, UBPManagedCommand*> Command : ManagedCommands)
+		for (const auto& Command : ManagedCommands)
 		{
 			//Do not broadcast on stop completion to avoid changing the array while we are iterating through it.
 			Command.Value->StopCommand(false);
-			Command.Value->MarkAsGarbage();
 		}
 		ManagedCommands.Empty();
 	}
@@ -357,24 +356,24 @@ FGuid UBPDeviceSubsystem::StartScalarPatternCommand(FBPDeviceObject TargetDevice
 												float InDurationSeconds, int32 UpdatesPerSecond)
 {
 	FGuid Out = FGuid::NewGuid();
-	ManagedCommands.Add(Out, UBPManagedCommand::CreateManagedCommand(this, TargetDevice, FInstancedStruct::Make<FBPScalarCommand>(InCommand), InPattern, InDurationSeconds, Out, UpdatesPerSecond));
-	ManagedCommands[Out]->OnCommandStopped.AddDynamic(this, &UBPDeviceSubsystem::OnCommandStopped);
+	ManagedCommands.Add(Out, FBPManagedCommand::CreateManagedCommand(this, TargetDevice, FInstancedStruct::Make<FBPScalarCommand>(InCommand), InPattern, InDurationSeconds, Out, UpdatesPerSecond));
+	ManagedCommands[Out]->OnCommandStopped.AddUObject(this, &UBPDeviceSubsystem::OnCommandStopped);
 	return Out;
 }
 
 FGuid UBPDeviceSubsystem::StartRotatePatternCommand(FBPDeviceObject TargetDevice, FBPRotateCommand InCommand, UCurveFloat* InPattern, float InDurationSeconds, int32 UpdatesPerSecond)
 {
 	FGuid Out = FGuid::NewGuid();
-	ManagedCommands.Add(Out, UBPManagedCommand::CreateManagedCommand(this, TargetDevice, FInstancedStruct::Make<FBPRotateCommand>(InCommand), InPattern, InDurationSeconds, Out, UpdatesPerSecond));
-	ManagedCommands[Out]->OnCommandStopped.AddDynamic(this, &UBPDeviceSubsystem::OnCommandStopped);
+	ManagedCommands.Add(Out, FBPManagedCommand::CreateManagedCommand(this, TargetDevice, FInstancedStruct::Make<FBPRotateCommand>(InCommand), InPattern, InDurationSeconds, Out, UpdatesPerSecond));
+	ManagedCommands[Out]->OnCommandStopped.AddUObject(this, &UBPDeviceSubsystem::OnCommandStopped);
 	return Out;
 }
 
 FGuid UBPDeviceSubsystem::StartLinearPatternCommand(FBPDeviceObject TargetDevice, FBPLinearCommand InCommand, UCurveFloat* InPattern, float InDurationSeconds, int32 UpdatesPerSecond)
 {
 	FGuid Out = FGuid::NewGuid();
-	ManagedCommands.Add(Out, UBPManagedCommand::CreateManagedCommand(this, TargetDevice, FInstancedStruct::Make<FBPLinearCommand>(InCommand), InPattern, InDurationSeconds, Out, UpdatesPerSecond));
-	ManagedCommands[Out]->OnCommandStopped.AddDynamic(this, &UBPDeviceSubsystem::OnCommandStopped);
+	ManagedCommands.Add(Out, FBPManagedCommand::CreateManagedCommand(this, TargetDevice, FInstancedStruct::Make<FBPLinearCommand>(InCommand), InPattern, InDurationSeconds, Out, UpdatesPerSecond));
+	ManagedCommands[Out]->OnCommandStopped.AddUObject(this, &UBPDeviceSubsystem::OnCommandStopped);
 	return Out;
 }
 
@@ -390,7 +389,6 @@ void UBPDeviceSubsystem::StopPatternCommand(FGuid CommandId)
 
 void UBPDeviceSubsystem::OnCommandStopped(FGuid CommandId)
 {
-	ManagedCommands[CommandId]->MarkAsGarbage();
 	ManagedCommands.Remove(CommandId);
 }
 

--- a/Source/ButtplugUE/Private/BPManagedCommand.cpp
+++ b/Source/ButtplugUE/Private/BPManagedCommand.cpp
@@ -5,17 +5,17 @@
 #include "Curves/CurveFloat.h"
 #include "GenericPlatform/GenericPlatformMath.h"
 
-#include "BPLogging.h"
 #include "BPDeviceSubsystem.h"
 
-UBPManagedCommand* UBPManagedCommand::CreateManagedCommand(UObject* Context, FBPDeviceObject TargetDevice, FInstancedStruct InCommand,
+TSharedPtr<FBPManagedCommand> FBPManagedCommand::CreateManagedCommand(UBPDeviceSubsystem* Subsystem, FBPDeviceObject TargetDevice, FInstancedStruct InCommand,
 															UCurveFloat* InPattern,  float InDurationSeconds, FGuid InId, int32 UpdatesPerSecond)
 {
-	UBPManagedCommand* Out = NewObject<UBPManagedCommand>(Context);
+	auto Out = MakeShared<FBPManagedCommand>();
 
+	Out->Subsystem = Subsystem;
 	Out->Device = TargetDevice;
 	Out->Command = InCommand;
-	Out->Pattern = InPattern;
+	Out->Pattern.Reset(InPattern);
 	Out->DurationSeconds = InDurationSeconds;
 	Out->Id = InId;
 
@@ -26,8 +26,18 @@ UBPManagedCommand* UBPManagedCommand::CreateManagedCommand(UObject* Context, FBP
 	return Out;
 }
 
-void UBPManagedCommand::UpdateDevice()
+void FBPManagedCommand::UpdateDevice()
 {
+	if (!Pattern)
+	{
+		return;
+	}
+
+	if (!Subsystem.IsValid())
+	{
+		return;
+	}
+
 	float TimeMin, TimeMax, PatternDuration;
 	Pattern->GetTimeRange(TimeMin, TimeMax);
 	PatternDuration = TimeMax - TimeMin;
@@ -37,43 +47,43 @@ void UBPManagedCommand::UpdateDevice()
 	{
 		FBPScalarCommand* SclCmd = Command.GetMutablePtr<FBPScalarCommand>();
 		SclCmd->Scalars[0].Scalar = NewStrength;
-		GetBP()->SendScalarCommand(*SclCmd, FBPInstancedResponseDelegate());
+		Subsystem->SendScalarCommand(*SclCmd, FBPInstancedResponseDelegate());
 	}
 	else if (Command.GetPtr<FBPRotateCommand>() != nullptr)
 	{
 		FBPRotateCommand* RotCmd = Command.GetMutablePtr<FBPRotateCommand>();
 		RotCmd->Rotations[0].Speed = NewStrength;
-		GetBP()->SendRotateCommand(*RotCmd, FBPInstancedResponseDelegate());
+		Subsystem->SendRotateCommand(*RotCmd, FBPInstancedResponseDelegate());
 	}
 	else if (Command.GetPtr<FBPLinearCommand>() != nullptr)
 	{
 		FBPLinearCommand* LinCmd = Command.GetMutablePtr<FBPLinearCommand>();
 		LinCmd->Vectors[0].Position = NewStrength;
-		GetBP()->SendLinearCommand(*LinCmd, FBPInstancedResponseDelegate());
+		Subsystem->SendLinearCommand(*LinCmd, FBPInstancedResponseDelegate());
 	}
 }
 
-void UBPManagedCommand::StopCommand(bool bBroadcastStop /*= true*/)
+void FBPManagedCommand::StopCommand(bool bBroadcastStop /*= true*/)
 {
 	bActive = false;
-	GetBP()->StopDevice(Device, FBPInstancedResponseDelegate(), false);
+
+	if (Subsystem.IsValid())
+	{
+		Subsystem->StopDevice(Device, FBPInstancedResponseDelegate(), false);
+	}
+
 	if(bBroadcastStop)
 	{
 		OnCommandStopped.Broadcast(Id);
 	}
 }
 
-FBPDeviceObject UBPManagedCommand::GetDevice() const
+FBPDeviceObject FBPManagedCommand::GetDevice() const
 {
 	return Device;
 }
 
-UBPDeviceSubsystem* UBPManagedCommand::GetBP() const
-{
-	return (UBPDeviceSubsystem*)GetOuter();
-}
-
-void UBPManagedCommand::Tick(float DeltaTime)
+void FBPManagedCommand::Tick(float DeltaTime)
 {
 	if (!bActive)
 	{
@@ -96,27 +106,27 @@ void UBPManagedCommand::Tick(float DeltaTime)
 	}
 }
 
-ETickableTickType UBPManagedCommand::GetTickableTickType() const
+ETickableTickType FBPManagedCommand::GetTickableTickType() const
 {
 	return ETickableTickType::Conditional;
 }
 
-TStatId UBPManagedCommand::GetStatId() const
+TStatId FBPManagedCommand::GetStatId() const
 {
 	RETURN_QUICK_DECLARE_CYCLE_STAT(FMyTickableThing, STATGROUP_Tickables);
 }
 
-bool UBPManagedCommand::IsTickable() const
+bool FBPManagedCommand::IsTickable() const
 {
 	return bActive;
 }
 
-bool UBPManagedCommand::IsTickableWhenPaused() const
+bool FBPManagedCommand::IsTickableWhenPaused() const
 {
 	return false;
 }
 
-bool UBPManagedCommand::IsTickableInEditor() const
+bool FBPManagedCommand::IsTickableInEditor() const
 {
 	return false;
 }

--- a/Source/ButtplugUE/Public/BPDeviceSubsystem.h
+++ b/Source/ButtplugUE/Public/BPDeviceSubsystem.h
@@ -47,7 +47,7 @@ DECLARE_DYNAMIC_DELEGATE_OneParam(FBPInstancedResponseDelegate, const FInstanced
 //Blank delegate, for simple triggers.
 DECLARE_DYNAMIC_MULTICAST_DELEGATE(FBPBasicDelegate);
 
-class UBPManagedCommand;
+class FBPManagedCommand;
 class UCurveFloat;
 
 /** This is the main Subsystem for communicating with Intiface, and by extension controlling devices.
@@ -155,8 +155,7 @@ private:
 	template<typename T, typename... TArgs>
 	int32 PackAndSendMessage(TOptional<FBPInstancedResponseDelegate> ResponseDelegate, TArgs&&... InArgs);
 
-	UPROPERTY()
-	TMap<FGuid, UBPManagedCommand*> ManagedCommands;
+	TMap<FGuid, TSharedPtr<FBPManagedCommand>> ManagedCommands;
 
 public:
 

--- a/Source/ButtplugUE/Public/BPManagedCommand.h
+++ b/Source/ButtplugUE/Public/BPManagedCommand.h
@@ -3,50 +3,39 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "UObject/NoExportTypes.h"
 #include "Tickable.h"
 
 #include "BPTypes.h"
 
-#include "BPManagedCommand.generated.h"
-
-DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FBPOnPatternCommandStopped, FGuid, PatternId);
-
 class UCurveFloat;
 class UBPDeviceSubsystem;
 
-/**
- * 
- */
-UCLASS()
-class BUTTPLUGUE_API UBPManagedCommand : public UObject, public FTickableGameObject
+class BUTTPLUGUE_API FBPManagedCommand : public FTickableGameObject, public FNoncopyable
 {
-	GENERATED_BODY()
-
 public:
 
-	FBPOnPatternCommandStopped OnCommandStopped;
+	TMulticastDelegate<void(const FGuid)> OnCommandStopped;
 
-	static UBPManagedCommand* CreateManagedCommand(UObject* Context, FBPDeviceObject TargetDevice, FInstancedStruct InCommand,
+	static TSharedPtr<FBPManagedCommand> CreateManagedCommand(UBPDeviceSubsystem* Subsystem, FBPDeviceObject TargetDevice, FInstancedStruct InCommand,
 													UCurveFloat* InPattern, float InDurationSeconds, FGuid InId, int32 UpdatesPerSecond = 10);
 	void StopCommand(bool bBroadcastStop = true);
 
 	FBPDeviceObject GetDevice() const;
 
 protected:
+
+	TWeakObjectPtr<UBPDeviceSubsystem> Subsystem;
 	
 	FBPDeviceObject Device;
 	FInstancedStruct Command;
-	UCurveFloat* Pattern;
-	float DurationSeconds;
+	TStrongObjectPtr<UCurveFloat> Pattern;
+	float DurationSeconds = 0;
 	float Runtime = 0.0f;
 	FGuid Id;
 
 	bool bActive = false;
 
 	void UpdateDevice();
-
-	UBPDeviceSubsystem* GetBP() const;
 
 public:
 


### PR DESCRIPTION
Rationale: there is no need to put pressure on GC

Also, prevent crash in BPManagedCommand::UpdateDevice if curve was not specified